### PR TITLE
Added oload.info to specific block

### DIFF
--- a/nocoin.txt
+++ b/nocoin.txt
@@ -25,4 +25,4 @@
 ||jyhfuqoh.info^$third-party
 ||kdowqlpt.info^$third-party
 ! specific block
-.info^$script,domain=oload.info|oload.tv|openload.co|streamango.com|streamcherry.com
+.info^$script,third-party,domain=oload.info|oload.tv|openload.co|streamango.com|streamcherry.com

--- a/nocoin.txt
+++ b/nocoin.txt
@@ -25,4 +25,4 @@
 ||jyhfuqoh.info^$third-party
 ||kdowqlpt.info^$third-party
 ! specific block
-.info^$script,domain=oload.tv|openload.co|streamango.com|streamcherry.com
+.info^$script,domain=oload.info|oload.tv|openload.co|streamango.com|streamcherry.com


### PR DESCRIPTION
`oload.info` is an `oload.tv`/`openload.co` mirror site.