### PR TITLE
add coinerra.com

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -7,7 +7,7 @@
 # License: https://mit-license.org/
 #
 # Last modified: 11 Oct 2017
-# 
+#
 
 127.0.0.1 localhost
 ::1 localhost
@@ -27,3 +27,4 @@
 0.0.0.0 kdowqlpt.info
 0.0.0.0 xbasfbno.info
 0.0.0.0 crypto-loot.com
+0.0.0.0 coinerra.com

--- a/nocoin.txt
+++ b/nocoin.txt
@@ -28,5 +28,6 @@
 ||kdowqlpt.info^$third-party
 ||2giga.link/js/hive.js
 ||crypto-loot.com^$third-party
+||coinerra.com^$third-party
 ! specific block
 .info^$script,third-party,domain=oload.info|oload.tv|openload.co|streamango.com|streamcherry.com


### PR DESCRIPTION
https://coinerra.com/ is a third party service that provides mining for websites.

Similar to coinhive.com