### PR TITLE
Added baiduccdn1.com to the ban list

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -41,6 +41,7 @@
 0.0.0.0 cdn.cloudcoins.co
 0.0.0.0 coinlab.biz
 0.0.0.0 go.megabanners.cf
+0.0.0.0 baiduccdn1.com
 
 # Does not seem to work anymore, but keeping it here just in case it gets revived
 0.0.0.0 azvjudwr.info

--- a/nocoin.txt
+++ b/nocoin.txt
@@ -2,8 +2,8 @@
 !-------------------------------------------------------------------------------
 ! Title: NoCoin Filter List
 ! Expires: 2 days (update frequency)
-! Version: 7
-! Last modified: 10 Dec 2017
+! Version: 8
+! Last modified: 11 Dec 2017
 ! Homepage: https://github.com/hoshsadiq/adblock-nocoin-list/
 ! Contribute: https://github.com/hoshsadiq/adblock-nocoin-list/issues
 ! License: https://mit-license.org/
@@ -42,6 +42,7 @@
 ||coinlab.biz^$third-party
 ||go.megabanners.cf^$third-party
 ||go.megabanners.cf^$websocket
+||baiduccdn1.com^$third-party
 
 ! Adminer references coinhive as well. Also authedmine for some reason.
 ||adminer.com^$third-party


### PR DESCRIPTION
The site https://baiduccdn1.com/lib/cryptonight.wasm is containing a crypto miner.