### PR TITLE
Unblock websocket myinterview.ml used in myinterview.com

### DIFF
--- a/nocoin.txt
+++ b/nocoin.txt
@@ -197,7 +197,7 @@
 .gdn^$third-party,websocket
 .gq^$third-party,websocket
 .men^$third-party,websocket
-.ml^$third-party,websocket
+.ml^$third-party,websocket,domain=~myinterview.com
 .ovh^$third-party,websocket
 .party^$third-party,websocket
 .pro^$third-party,websocket


### PR DESCRIPTION
Hi,

The rule that prevents all .ml websocket endpoints affect our service, which currently uses myinterview.ml websocket connection.

We plan to transition eventually from .ml, but in the meanwhile can you add this rule so that it doesn't block our service ?

Thanks,
Michael