### PR TITLE
Fix coinimp filters

### DIFF
--- a/nocoin.txt
+++ b/nocoin.txt
@@ -47,8 +47,8 @@
 ||sparechange.io^$third-party
 ||zlx.com.br^$third-party
 ||m.anyfiles.ovh^
-||coinimp.com$third-party
-||coinimp.net$third-party
+||coinimp.com^$third-party
+||coinimp.net^$third-party
 ||freecontent.bid
 ||freecontent.date
 ||freecontent.faith


### PR DESCRIPTION
This fixes a bug in the filters that were added in #242. Per [AdBlock Plus documentation](https://adblockplus.org/en/filter-cheatsheet), there should always be a `^`  before the option separator (`$`) to mark the end of the domain.