### PR TITLE
Remove JSECoin

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -13,9 +13,6 @@
 0.0.0.0 coin-hive.com
 0.0.0.0 coinhive.com
 0.0.0.0 authedmine.com
-0.0.0.0 api.jsecoin.com
-0.0.0.0 load.jsecoin.com
-0.0.0.0 server.jsecoin.com
 0.0.0.0 miner.pr0gramm.com
 0.0.0.0 minemytraffic.com
 0.0.0.0 ppoi.org

--- a/nocoin.txt
+++ b/nocoin.txt
@@ -14,7 +14,6 @@
 ||coin-hive.com^$third-party
 ||coinhive.com^$third-party
 ||authedmine.com^$third-party,domain=~coinhive.com
-||jsecoin.com^$third-party
 ||185.165.169.108^$third-party
 ||35.194.26.233^$third-party
 ||35.239.57.233^$third-party
@@ -496,7 +495,6 @@
 /hash.wasm
 /helper.wasm$third-party
 /inject.js?key=$script
-/jsecoin.*/?
 /lhnhelpouttab-current.min.js
 /lib/crlt.js$script,third-party
 /media/miner.


### PR DESCRIPTION
I don't think JSECoin deserves blockage. If you visit some JSECoin monetized site, it uses only a few percents of CPU and you'll see popup, where you are informed about it and you can easily opt-out of JSE mining across whole network. JSE is great project and it should be followed by other browser miners, which often almost destroy your CPU. So it would be great to remove JSE from this list and let it grow.