### PR TITLE
Adding note about Manifest v3 + improved the uBO entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # NoCoin adblock list
 This is an adblock list to block "browser-based crypto mining". Currently there are a few websites added into the lists. If you see other websites supporting these deeds, then feel free to raise an **Issue** or **Pull request** for it to be taken care of.
 
+##
+
+<b>IMPORTANT NOTE FOR CHROMIUM-BROWSER USERS:</b> Our list does not, can not, and will never ever support Manifest v3, due to its laughably short rule limit and the removal of `csp` and `##+js`. Issue reports for Manifest v3-based extension versions will not be accepted, and if you do submit one, you would be asked to use an alternate web browser or web browser version instead.
+
 ## Installation
 
 ### AdBlock Filter

--- a/nocoin-ublock.txt
+++ b/nocoin-ublock.txt
@@ -1,10 +1,10 @@
 # NoCoin filter list optimized for uBlock
 
-csgoconfigs.com##script:inject(abort-current-inline-script.js, m, CH.Anonymous)
-djs.sk,mladipodnikatelia.sk,tubettajat.net##script:inject(abort-on-property-read.js, miner)
-tasma.ru,vidzi.tv##script:inject(abort-on-property-write.js, decodeURIComponent)
-cloudtime.to,nowvideo.sx,sleeptimer.org,tomadivx.tv,wholecloud.net##script:inject(abort-on-property-read.js, WebAssembly)
-123telugu.com,netiap.com,tomtop.com##script:inject(abort-on-property-read.js, _0x7bc7)
-thepiratebay.*##script:inject(abort-on-property-read.js, _wm)
-hqq.tv,hqq.watch##script:inject(abort-on-property-read.js,  mscript)
-descargas2020.com##script:inject(abort-current-inline-script.js, atob, _0x)
+csgoconfigs.com##+js(abort-current-inline-script.js, m, CH.Anonymous)
+djs.sk,mladipodnikatelia.sk,tubettajat.net##+js(abort-on-property-read.js, miner)
+tasma.ru,vidzi.tv##+js(abort-on-property-write.js, decodeURIComponent)
+cloudtime.to,nowvideo.sx,sleeptimer.org,tomadivx.tv,wholecloud.net##+js(abort-on-property-read.js, WebAssembly)
+123telugu.com,netiap.com,tomtop.com##+js(abort-on-property-read.js, _0x7bc7)
+thepiratebay.*##+js(abort-on-property-read.js, _wm)
+hqq.tv,hqq.watch##+js(abort-on-property-read.js,  mscript)
+descargas2020.com##+js(abort-current-inline-script.js, atob, _0x)


### PR DESCRIPTION
Greetings, Dandelion Sprout here, the maintainer of *Dandelion Sprout's Nordic Filters* and an adblocker enthusiast in general.

So it seems that the Chromium team [has decided to follow through with their war on adblockers](https://9to5google.com/2019/05/29/chrome-ad-blocking-enterprise-manifest-v3/), by having a laughably small current rule limit of 35,000 and by removing most of the more advanced syntaxes that recent adblocker versions can use from October-ish onwards. So tonight I've decided to venture a bit around on the GitHub issue trackers of various lists that are included in adblockers, and get them to publicly take a stance against Manifest v3, in order to educate laymen and to establish *some* kind of pressure on the Chromium team.

While I can see that your list would be among the least affected ones by Manifest v3, due to its few entries and limited use of advanced syntaxes, I presume that it'd limit your ability to deal with deep mining scripts, your ability to get natively included in adblockers, and the users' ability to subscribe to your list if they already subscribe to one or two other lists.

As a bonus, I've also changed the `##script:inject` entries into `##+js`, as the former has been deprecated by the uBO team and renamed to the latter.

I've turned on the ability for maintainers to edit this pull, should you guys want to do any changes to the note's text on your own.