### PR TITLE
Turtlecoin added

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -705,3 +705,11 @@
 0.0.0.0 srcips.com
 0.0.0.0 gxbrowser.net
 0.0.0.0 contribute.to-support.me
+0.0.0.0 turtlecoin.herominers.com
+0.0.0.0 de.turtlecoin.herominers.com
+0.0.0.0 tr.turtlecoin.herominers.com
+0.0.0.0 fi.turtlecoin.herominers.com
+0.0.0.0 ca.turtlecoin.herominers.com
+0.0.0.0 us.turtlecoin.herominers.com
+0.0.0.0 hk.turtlecoin.herominers.com
+0.0.0.0 sg.turtlecoin.herominers.com


### PR DESCRIPTION
New sites added turtlecoin.herominers.com and its subdomains added.