### PR TITLE
Allow live.api.stream websockets

### DIFF
--- a/nocoin.txt
+++ b/nocoin.txt
@@ -666,6 +666,7 @@ $script,websocket,domain=pirateproxy.buzz|pirateproxy.ist|pirateproxy.mx|thepira
 @@||broadcastt.xyz/apps/$websocket
 @@||lags.win/ctf$websocket
 @@||siteapi.idkfa.online/v2/units/socket/websocket?$websocket
+@@||live.api.stream^$websocket
 
 ! Filters optimized for uBlock -------------------------------------------------
 !#include nocoin-ublock.txt


### PR DESCRIPTION
Hi! We've ran into some trouble with this adblock list incorrectly blocking our websocket connections to `live.api.stream` due to us using the .stream TLD. Our product and the backing apis are around video broadcasting, not crypto.

Context:
The platform to be whitelisted is https://api.stream -- you can find our demo app here: https://github.com/golightstream/api.stream-studio-kit (although our hosted demo doesn't run into trouble as it's not cross-domain)

We're primarily seeing this impact customers in our product, which uses the same apis (https://studio.golightstream.com/v2) -- this is where we're seeing our websocket connections blocked.